### PR TITLE
Conda environment update, and devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/anaconda:1.3.10-3
+
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN <<EOF_COMPILE
+rm /opt/conda/.condarc
+conda config --add channels conda-forge
+umask 0002
+/opt/conda/bin/conda env create --file /tmp/conda-tmp/environment.yml
+rm -rf /tmp/conda-tmp
+EOF_COMPILE
+
+USER vscode
+RUN <<EOF_USERSETUP
+conda config --add channels conda-forge
+conda config --remove channels defaults
+conda init bash
+EOF_USERSETUP

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,18 +2,12 @@ FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/anaconda:1.3.10-3
 
 # Copy environment.yml (if found) to a temp location so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
-COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
-RUN <<EOF_COMPILE
-rm /opt/conda/.condarc
-conda config --add channels conda-forge
-umask 0002
-/opt/conda/bin/conda env create --file /tmp/conda-tmp/environment.yml
-rm -rf /tmp/conda-tmp
-EOF_COMPILE
-
 USER vscode
-RUN <<EOF_USERSETUP
+COPY environment.yml /home/vscode
+RUN <<EOF_USERSETUPINSTALL
 conda config --add channels conda-forge
 conda config --remove channels defaults
 conda init bash
-EOF_USERSETUP
+conda env create --file /home/vscode/environment.yml
+rm /home/vscode/environment.yml
+EOF_USERSETUPINSTALL

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
+{
+	"name": "Anaconda (Python 3)",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "python --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file copied into the container along with environment.yml* from the parent
+folder. This file is included to prevents the Dockerfile COPY instruction from 
+failing if no environment.yml is found.

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tests
 !tests/*.py
 __pycache__/*
 RIP/*.sif
-
+.devcontainer/devcontainer-lock.json

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,8 @@ dependencies:
 #  - pynio==1.5     #Reccomended by wrf-python, not needed for Plotting a Two-dimensional Field script
 #  - pyngl==1.6     #Reccomended by wrf-python, not needed for Plotting a Two-dimensional Field script
 #  - basemap==1.3   #Reccomended by wrf-python, not needed for Plotting a Two-dimensional Field script
-  - wrf-python==1.3.4
+  - wrf-python==1.3.4.1
   - imageio==2.19.3
   - imageio-ffmpeg==0.4.7
   - metpy==1.5.1
+  - setuptools==79.0.1


### PR DESCRIPTION
This adds a devcontainer config file for VS Code, and also fixes the conda environment - pinning setuptools to version 79.0.1 to avoid the removal of `pkg_resources` from that library.